### PR TITLE
Fix crash when used within Jest environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,7 @@ if (useTrap) {
   // trap the createSecureContext method and inject custom root CAs whenever invoked
   const origCreateSecureContext = tls.createSecureContext;
   tls.createSecureContext = function(options) {
+    options = options || {};
     var c = origCreateSecureContext.apply(null, arguments);
     if (!options.ca && rootCAs.length > 0) {
       rootCAs.forEach(function(ca) {


### PR DESCRIPTION
In some environment, such as when running from Jest, the `createSecureContext` will apparently be called with a null option object, which makes the following `options.ca` access fail.

So this fix check if the options object is defined and if not, set it to an empty object.